### PR TITLE
Add global .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: "Never"
+IndentCaseLabels: false
+ColumnLimit: 0
+DerivePointerAlignment: true
+PointerAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,4 @@ IndentCaseLabels: false
 ColumnLimit: 0
 DerivePointerAlignment: false
 PointerAlignment: Right
+AccessModifierOffset: -4

--- a/.clang-format
+++ b/.clang-format
@@ -5,5 +5,5 @@ BreakBeforeBraces: Allman
 AllowShortIfStatementsOnASingleLine: "Never"
 IndentCaseLabels: false
 ColumnLimit: 0
-DerivePointerAlignment: true
-PointerAlignment: Left
+DerivePointerAlignment: false
+PointerAlignment: Right

--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,5 @@ ColumnLimit: 0
 DerivePointerAlignment: false
 PointerAlignment: Right
 AccessModifierOffset: -4
+AlignConsecutiveMacros: true
+IndentPPDirectives: BeforeHash

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ BasedOnStyle: LLVM
 IndentWidth: 4
 UseTab: Never
 BreakBeforeBraces: Allman
-AllowShortIfStatementsOnASingleLine: "Never"
+AllowShortIfStatementsOnASingleLine: Never
 IndentCaseLabels: false
 ColumnLimit: 0
 DerivePointerAlignment: false

--- a/src/grammar/runtime/.clang-format
+++ b/src/grammar/runtime/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: false


### PR DESCRIPTION
It seems like VSCode's C/C++ plugin comes with some rules for the clang-format linter (based on Visual Studio preset?). Not everyone uses VSCode, so I have added a global config file at the root of the project that describes the same rules. 

And also:

```
DerivePointerAlignment: true
PointerAlignment: Left
```

Need a review!