### PR TITLE
 Fix Windows std::print(const i8*, bool) overload 

### DIFF
--- a/std/io.sn
+++ b/std/io.sn
@@ -54,7 +54,7 @@ namespace std {
         std::memory::deallocate(count);
     }
 
-    fn print(str: const i8*) {
+    fn print(str: const i8*, new_line: bool) {
         let handle = GetStdHandle(-11);
         let count = std::memory::allocate<u64>(1);
 


### PR DESCRIPTION
please make sure its correct this time 😄 